### PR TITLE
Fixed a typo

### DIFF
--- a/content/posts/079-object-destructuring/index.md
+++ b/content/posts/079-object-destructuring/index.md
@@ -191,7 +191,7 @@ Now, instead of being `undefined`, the variable `enemies` defaults to `['Joker']
 
 ## 5. Aliases
 
-If you'd like to create variables of different names that the properties, then you can use the aliasing feature of object destructuring.  
+If you'd like to create variables of different names than the properties, then you can use the aliasing feature of object destructuring.  
 
 ```javascript
 const { identifier: aliasIdentifier } = expression;


### PR DESCRIPTION
Under Aliases based on the structure of the sentence:

> If you'd like to create variables of different names that the properties

I think you intend to write:

> If you'd like to create variables of different names __than__ the properties