### PR TITLE
fix: typo fixed  `useContext`

### DIFF
--- a/content/posts/147-react-context/index.md
+++ b/content/posts/147-react-context/index.md
@@ -57,7 +57,7 @@ Again, what's important here is that all the components that'd like later to con
 
 Consuming the context can be performed in 2 ways.  
 
-The first way, the one I recommend, is to use the `userContext(Context)` React hook:
+The first way, the one I recommend, is to use the `useContext(Context)` React hook:
 
 ```jsx{4}
 import { useContext } from 'react';


### PR DESCRIPTION
There is a typo in section `C: Consuming a Context`, instead of writing `useContext()` you have misspelled it to `userContext()`
Thanks