### PR TITLE
Fix typo in post 80

### DIFF
--- a/posts/080-arrow-vs-regular-functions/index.md
+++ b/posts/080-arrow-vs-regular-functions/index.md
@@ -288,7 +288,7 @@ Usually, regular functions as methods are the way to go.
 
 Sometimes you'd need to supply the method as a callback, for example to `setTimeout()` or an event listener. In such cases, you might encounter difficulties accessing `this` value.  
 
-For example, let's use use `logName()` method as a callback to `setTimeout()`:
+For example, let's use `logName()` method as a callback to `setTimeout()`:
 
 ```javascript
 setTimeout(batman.logName, 1000);


### PR DESCRIPTION
Removed double `use` word in post 80 - https://dmitripavlutin.com/differences-between-arrow-and-regular-functions/#:~:text=For%20example%2C%20let%27s-,use%20use,-logName()%20method